### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.0...v0.1.1) - 2024-01-27
+
+### Other
+- removed explicit rust-toolchain, so let's use the latest stable by default
+- Upgraded NEAR crates to 0.20.0 release ([#5](https://github.com/near-cli-rs/near-validator-cli-rs/pull/5))
+- fixed code_style.yml to use ubuntu-latest instead of ubuntu-20.04
+- removed old CI integrations that are now replaced by cargo-dist (release.yml workflow)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "near-validator"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-validator"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "FroVolod <frol_off@meta.ua>",
     "frol <frolvlad@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `near-validator`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.0...v0.1.1) - 2024-01-27

### Other
- removed explicit rust-toolchain, so let's use the latest stable by default
- Upgraded NEAR crates to 0.20.0 release ([#5](https://github.com/near-cli-rs/near-validator-cli-rs/pull/5))
- fixed code_style.yml to use ubuntu-latest instead of ubuntu-20.04
- removed old CI integrations that are now replaced by cargo-dist (release.yml workflow)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).