### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.1...v0.1.2) - 2024-02-03
+
+### Other
+- Updated binary releases pipeline to use cargo-dist v0.9.0 (previously v0.7.2) ([#8](https://github.com/near-cli-rs/near-validator-cli-rs/pull/8))
+
 ## [0.1.1](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.0...v0.1.1) - 2024-01-27
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "near-validator"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-validator"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     "FroVolod <frol_off@meta.ua>",
     "frol <frolvlad@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `near-validator`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.1...v0.1.2) - 2024-02-03

### Other
- Updated binary releases pipeline to use cargo-dist v0.9.0 (previously v0.7.2) ([#8](https://github.com/near-cli-rs/near-validator-cli-rs/pull/8))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).