### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.3...v0.1.4) - 2024-08-21
+
+### Added
+- Use whole NEAR amounts when displaying stake in the tables since the <0.1 NEAR is irrelevant for the users ([#16](https://github.com/near-cli-rs/near-validator-cli-rs/pull/16))
+
 ## [0.1.3](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.2...v0.1.3) - 2024-08-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "near-validator"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-validator"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
     "FroVolod <frol_off@meta.ua>",
     "frol <frolvlad@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `near-validator`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.3...v0.1.4) - 2024-08-21

### Added
- Use whole NEAR amounts when displaying stake in the tables since the <0.1 NEAR is irrelevant for the users ([#16](https://github.com/near-cli-rs/near-validator-cli-rs/pull/16))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).