### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.4...v0.1.5) - 2025-03-27
+
+### Other
+
+- Updated near-cli-rs crate to 0.19 release ([#18](https://github.com/near-cli-rs/near-validator-cli-rs/pull/18))
+
 ## [0.1.4](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.3...v0.1.4) - 2024-08-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,7 +2252,7 @@ dependencies = [
 
 [[package]]
 name = "near-validator"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-validator"
-version = "0.1.4"
+version = "0.1.5"
 authors = [
     "FroVolod <frol_off@meta.ua>",
     "frol <frolvlad@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-validator`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.4...v0.1.5) - 2025-03-27

### Other

- Updated near-cli-rs crate to 0.19 release ([#18](https://github.com/near-cli-rs/near-validator-cli-rs/pull/18))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).