### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.5...v0.1.6) - 2025-03-29
+
+### Added
+
+- Upgraded cargo-dist to 0.28.0 ([#21](https://github.com/near-cli-rs/near-validator-cli-rs/pull/21))
+
+### Other
+
+- Replaced integer casts with explicit From trait calls
+
 ## [0.1.5](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.4...v0.1.5) - 2025-03-27
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,7 +2252,7 @@ dependencies = [
 
 [[package]]
 name = "near-validator"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-validator"
-version = "0.1.5"
+version = "0.1.6"
 authors = [
     "FroVolod <frol_off@meta.ua>",
     "frol <frolvlad@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-validator`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.5...v0.1.6) - 2025-03-29

### Added

- Upgraded cargo-dist to 0.28.0 ([#21](https://github.com/near-cli-rs/near-validator-cli-rs/pull/21))

### Other

- Replaced integer casts with explicit From trait calls
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).