### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.6...v0.1.7) - 2025-07-08
+
+### Fixed
+
+- Use RpcConfigError error type instead of () for ProtocolConfig requests ([#26](https://github.com/near-cli-rs/near-validator-cli-rs/pull/26))
+- Fixed error RpcError: [missing field disable_9393_fix]  ([#22](https://github.com/near-cli-rs/near-validator-cli-rs/pull/22))
+
+### Other
+
+- Replaced ubuntu-20.04, being browned out ([#25](https://github.com/near-cli-rs/near-validator-cli-rs/pull/25))
+
 ## [0.1.6](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.5...v0.1.6) - 2025-03-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "near-validator"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-validator"
-version = "0.1.6"
+version = "0.1.7"
 authors = [
     "FroVolod <frol_off@meta.ua>",
     "frol <frolvlad@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-validator`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.7](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.6...v0.1.7) - 2025-07-08

### Fixed

- Use RpcConfigError error type instead of () for ProtocolConfig requests ([#26](https://github.com/near-cli-rs/near-validator-cli-rs/pull/26))
- Fixed error RpcError: [missing field disable_9393_fix]  ([#22](https://github.com/near-cli-rs/near-validator-cli-rs/pull/22))

### Other

- Replaced ubuntu-20.04, being browned out ([#25](https://github.com/near-cli-rs/near-validator-cli-rs/pull/25))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).