### PR TITLE
chore: release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - update near-* dependencies to 0.31 release ([#28](https://github.com/near-cli-rs/near-validator-cli-rs/pull/28))
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
 
 ## [0.1.7](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.6...v0.1.7) - 2025-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.8](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.7...v0.1.8) - 2025-08-31
+
+### Added
+
+- Added self update for near-validator ([#27](https://github.com/near-cli-rs/near-validator-cli-rs/pull/27))
+
+### Other
+
+- update near-* dependencies to 0.31 release ([#28](https://github.com/near-cli-rs/near-validator-cli-rs/pull/28))
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "near-validator"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-validator"
-version = "0.1.7"
+version = "0.1.8"
 authors = [
     "FroVolod <frol_off@meta.ua>",
     "frol <frolvlad@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-validator`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).