### PR TITLE
chore: release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.8...v0.1.9) - 2026-01-09
+
+### Added
+
+- Enabled aarch64 Windows binary builds (upgraded cargo-dist to 0.29.0) ([#30](https://github.com/near-cli-rs/near-validator-cli-rs/pull/30))
+
+### Other
+
+- Updated near-cli-rs crate to 0.23.5 release ([#32](https://github.com/near-cli-rs/near-validator-cli-rs/pull/32))
+
 ## [0.1.8](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.7...v0.1.8) - 2025-08-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "near-validator"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-validator"
-version = "0.1.8"
+version = "0.1.9"
 authors = [
     "FroVolod <frol_off@meta.ua>",
     "frol <frolvlad@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-validator`: 0.1.8 -> 0.1.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.9](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.8...v0.1.9) - 2026-01-09

### Added

- Enabled aarch64 Windows binary builds (upgraded cargo-dist to 0.29.0) ([#30](https://github.com/near-cli-rs/near-validator-cli-rs/pull/30))

### Other

- Updated near-cli-rs crate to 0.23.5 release ([#32](https://github.com/near-cli-rs/near-validator-cli-rs/pull/32))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).