### PR TITLE
chore: release v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/near/near-validator-cli-rs/compare/v0.1.9...v0.1.10) - 2026-06-08
+
+### Added
+
+- Added styling options for "newline", "option selection" and "answer" for "inquire" crate ([#35](https://github.com/near/near-validator-cli-rs/pull/35))
+
+### Other
+
+- bump near-* deps to nearcore 2.12 / protocol 84 + fix protocol-config deserialization ([#37](https://github.com/near/near-validator-cli-rs/pull/37))
+- upgrade to Rust edition 2024 ([#34](https://github.com/near/near-validator-cli-rs/pull/34))
+- migrate to org-wide NEARPROTOCOL_CI_PR_ACCESS token ([#33](https://github.com/near/near-validator-cli-rs/pull/33))
+
 ## [0.1.9](https://github.com/near-cli-rs/near-validator-cli-rs/compare/v0.1.8...v0.1.9) - 2026-01-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "near-validator"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-validator"
-version = "0.1.9"
+version = "0.1.10"
 authors = [
     "FroVolod <frol_off@meta.ua>",
     "frol <frolvlad@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-validator`: 0.1.9 -> 0.1.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.10](https://github.com/near/near-validator-cli-rs/compare/v0.1.9...v0.1.10) - 2026-06-08

### Added

- Added styling options for "newline", "option selection" and "answer" for "inquire" crate ([#35](https://github.com/near/near-validator-cli-rs/pull/35))

### Other

- bump near-* deps to nearcore 2.12 / protocol 84 + fix protocol-config deserialization ([#37](https://github.com/near/near-validator-cli-rs/pull/37))
- upgrade to Rust edition 2024 ([#34](https://github.com/near/near-validator-cli-rs/pull/34))
- migrate to org-wide NEARPROTOCOL_CI_PR_ACCESS token ([#33](https://github.com/near/near-validator-cli-rs/pull/33))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).