### PR TITLE
chore: release v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/near/near-validator-cli-rs/compare/v0.1.10...v0.1.11) - 2026-06-08
+
+### Other
+
+- Fixed Trusted Publishing (id-token: write)
+
 ## [0.1.10](https://github.com/near/near-validator-cli-rs/compare/v0.1.9...v0.1.10) - 2026-06-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "near-validator"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-validator"
-version = "0.1.10"
+version = "0.1.11"
 authors = [
     "FroVolod <frol_off@meta.ua>",
     "frol <frolvlad@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-validator`: 0.1.10 -> 0.1.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.11](https://github.com/near/near-validator-cli-rs/compare/v0.1.10...v0.1.11) - 2026-06-08

### Other

- Fixed Trusted Publishing (id-token: write)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).