### PR TITLE
chore: release v0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/near/near-validator-cli-rs/compare/v0.1.11...v0.1.12) - 2026-06-17
+
+### Other
+
+- Fixed NPM publishing (enable Trusted Publishing on NPM)
+
 ## [0.1.11](https://github.com/near/near-validator-cli-rs/compare/v0.1.10...v0.1.11) - 2026-06-08
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "near-validator"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-validator"
-version = "0.1.11"
+version = "0.1.12"
 authors = [
     "FroVolod <frol_off@meta.ua>",
     "frol <frolvlad@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-validator`: 0.1.11 -> 0.1.12

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.12](https://github.com/near/near-validator-cli-rs/compare/v0.1.11...v0.1.12) - 2026-06-17

### Other

- Fixed NPM publishing (enable Trusted Publishing on NPM)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).