### PR TITLE
chore: release v0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/near/near-validator-cli-rs/compare/v0.1.12...v0.1.13) - 2026-06-17
+
+### Other
+
+- Fixed NPM publishing (enable Trusted Publishing on NPM) - use Node.js 24.x as npm 11+ is required
+
 ## [0.1.12](https://github.com/near/near-validator-cli-rs/compare/v0.1.11...v0.1.12) - 2026-06-17
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "near-validator"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-validator"
-version = "0.1.12"
+version = "0.1.13"
 authors = [
     "FroVolod <frol_off@meta.ua>",
     "frol <frolvlad@gmail.com>",

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -173,7 +173,7 @@
         <!--<Icon Id='ProductICO' SourceFile='wix\Product.ico'/>-->
         <!--<Property Id='ARPPRODUCTICON' Value='ProductICO' />-->
 
-        <Property Id='ARPHELPLINK' Value='https://github.com/near-cli-rs/near-validator-cli-rs'/>
+        <Property Id='ARPHELPLINK' Value='https://github.com/near/near-validator-cli-rs'/>
         
         <UI>
             <UIRef Id='WixUI_FeatureTree'/>


### PR DESCRIPTION



## 🤖 New release

* `near-validator`: 0.1.12 -> 0.1.13

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.13](https://github.com/near/near-validator-cli-rs/compare/v0.1.12...v0.1.13) - 2026-06-17

### Other

- Fixed NPM publishing (enable Trusted Publishing on NPM) - use Node.js 24.x as npm 11+ is required
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).