### PR TITLE
feat: support nearcore 2.13 / post-quantum ML-DSA-65 (draft)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,11 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+      # near-crypto (post-quantum ML-DSA-65) pulls in aws-lc-sys, which needs
+      # NASM to assemble its x86_64 Windows code. Use aws-lc-sys's pregenerated
+      # NASM objects so the x86_64-pc-windows-msvc build doesn't require NASM on
+      # the runner. (aarch64 Windows / unix targets ignore this variable.)
+      AWS_LC_SYS_PREBUILT_NASM: "1"
     steps:
       - name: enable windows longpaths
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/near/near-validator-cli-rs/compare/v0.1.13...v0.2.0) - 2026-07-09
+
+### Added
+
+- Support for nearcore 2.13 (protocol 86) and post-quantum ML-DSA-65 signatures
+
+### Fixed
+
+- Reject non-ed25519 validator keys in stake/unstake proposals
+
 ## [0.1.13](https://github.com/near/near-validator-cli-rs/compare/v0.1.12...v0.1.13) - 2026-06-17
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +457,15 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "color-eyre"
@@ -971,6 +1003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1223,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -2110,9 +2154,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad19244d6390aa12020ed3f5971ea452fb54aa8b8f6435d4cf0cbbbc8fbd302"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -2136,8 +2179,7 @@ dependencies = [
 [[package]]
 name = "near-cli-rs"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40cfd499c512b5989a8ac8ab7b7dba2e326d49da330c7d52a44b6f8c9cdbcaca"
+source = "git+https://github.com/near/near-cli-rs?rev=178be1a97e19e354d5ca0e7b6a1531d9577f29fc#178be1a97e19e354d5ca0e7b6a1531d9577f29fc"
 dependencies = [
  "bip39",
  "borsh",
@@ -2195,9 +2237,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0238af1d79fd3841817e3a5861bb628ba825669f211ca379836ae716da67bb21"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -2207,10 +2248,10 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe9390bf0db47f0a34386ef6a30adc1270288874b7eac5cab7fa48d3f89fe03"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
+ "aws-lc-rs",
  "blake2",
  "borsh",
  "bs58 0.4.0",
@@ -2227,15 +2268,15 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
+ "sha3",
  "subtle",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "near-fmt"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503fac5d4e533a6d5e2c642cd22bd2400d1159dd5b2db58072dfc183a288c273"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "near-primitives-core",
 ]
@@ -2254,8 +2295,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614359c17b9cbf5faf2d82ecfe10d7a79b588c51f5f04517f75eff09f1751cdb"
+source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=5f5d150d47315745945fba7672bf8c90c5bf7f95#5f5d150d47315745945fba7672bf8c90c5bf7f95"
 dependencies = [
  "borsh",
  "lazy_static",
@@ -2272,9 +2312,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fa313996117ffead7c6f8eb12bb2b83e6ad569c7c2fd58d406c0f53ed06e01"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -2290,9 +2329,8 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89a9337ab742575d6dc9770ee7d4398de8cec8bbe5eaf25f00349f4e13d0173"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "borsh",
  "enum-map",
@@ -2309,9 +2347,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381f54f821ecdddfaccba5815a8d72bb4bb7abacac79783ce86841518523c591"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -2352,9 +2389,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5660ac51d24534bc144e7cc04f702921c22a7e2553072663d4b43a56a8bb1ae7"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -2376,15 +2412,13 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ad456b1bd9876772d6c0b557d100d518d60dd13e359daca8e0293828e29a05"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebdeed0043b2309b306984e4d3eeff6777ba6c66a2f955d34f883fd4ce7f84f2"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "near-schema-checker-core",
  "near-schema-checker-macro",
@@ -2392,9 +2426,8 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731a7b9cc155e291f149f2f6f8f88f5cab512b772aaf301f9defb4e4bceb1629"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 
 [[package]]
 name = "near-slip10"
@@ -2410,8 +2443,7 @@ dependencies = [
 [[package]]
 name = "near-socialdb-client"
 version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7cd480aad6faff2ba872e3368cd17b96db3b4244621e59bb8b95df984607a8"
+source = "git+https://github.com/near/near-socialdb-client-rs?rev=2268c29c4e8ad095de2a511521f08411858a1811#2268c29c4e8ad095de2a511521f08411858a1811"
 dependencies = [
  "eyre",
  "near-crypto",
@@ -2426,15 +2458,13 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f35191f9d7a78d5cdca9788e648dce89ebbb74faef4abfa6992ed7f1fb300369"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 
 [[package]]
 name = "near-time"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba02806ee8691aaf41717febbe09f8e8b60ff145f09f0fc23438c07a370b3b7"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "parking_lot",
  "serde",
@@ -3138,7 +3168,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3254,7 +3284,7 @@ checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4359,6 +4389,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd54ba00e601c21619a33d6e127cf0d604ee6c3080d8989492a0faf88cbc5b4"
+checksum = "139112ed78ed5f62ace80e88f4fe2de3edad1a94b90431263b18654d62473e9a"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -2180,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "near-cli-rs"
 version = "0.27.0"
-source = "git+https://github.com/near/near-cli-rs?rev=f239a8fdc09d15c60c826f04c8544b1a8fba4418#f239a8fdc09d15c60c826f04c8544b1a8fba4418"
+source = "git+https://github.com/near/near-cli-rs?rev=e170e55345c05f57eab0f3527f4c6bcb73a492b9#e170e55345c05f57eab0f3527f4c6bcb73a492b9"
 dependencies = [
  "bip39",
  "borsh",
@@ -2238,9 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc29612694210b340ff04d94c539e0d65007c97fc4763075a1d6038e58778a1"
+checksum = "a4b30e07d9eb158f1084a36db8963262f75a353b0093a033aa0529faae9db108"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -2250,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48363b16b2cfb9776c93c9ca9c470ed6437a2adb997afa0212372b3130cd944a"
+checksum = "9ee338484a9348f3768f4d636a98875f746b9dfeb58f4d7761e70ff74f3ddbb5"
 dependencies = [
  "aws-lc-rs",
  "blake2",
@@ -2278,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d603b7171fdb5f5200b4d805c9361d54bb2568e5b0636b4f2a3b37e5e3b7549b"
+checksum = "1bf5e92ed9616818b0cbedcc582d2a582194334f9b622276580453624712380b"
 dependencies = [
  "near-primitives-core",
 ]
@@ -2299,7 +2299,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.21.1"
-source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=b1ea63913de39768f4c40affaaf958e79704710d#b1ea63913de39768f4c40affaaf958e79704710d"
+source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=4196c34db5c5e6acfc563d62ab16c68b7c666d7e#4196c34db5c5e6acfc563d62ab16c68b7c666d7e"
 dependencies = [
  "borsh",
  "lazy_static",
@@ -2316,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2422d73d08d6e3add41e1237443699a27e6150962cbe91aeef14dc2e937a7d26"
+checksum = "79ada6f8e357a6eecba4947cb21e56abc58036fcab2136a438b358a4042b62a6"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -2334,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e376dc8810d6fa5bd295870c767a9418ef5f239e469ca0d7360bed3e89c703"
+checksum = "c9a94eb0bc87f470537646ea6bc5b5b9272bcceb8a798a1bd47e938f8737454a"
 dependencies = [
  "borsh",
  "enum-map",
@@ -2353,9 +2353,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec7cdd531c3a0cd6c199f183ad6c74755d08344c13f4eab8edd1641fb74a18f"
+checksum = "b5704a32bee9023c61c725ed6403f6bfdd21226e4798d74312b427c5a0f7022c"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -2396,9 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69db87d9459f45873002def58c11b0ff9c55454ca3793ac9cec396aaa0e27d"
+checksum = "f94564d97ca478c94b8a34fdcda0a0077b967fa83e7187c6b8267e9b6e441d47"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -2420,15 +2420,15 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9ab211568bffbc9b76fb87796a28fd4027cbaeccd4bd4743720d4de4fa48fd"
+checksum = "481ec75b745264fa2403643acde2402536ed4273fbf05ea8749a5d1813f683a0"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0170e3ee9be1a8f3d0fc5f3f21015fdc00aae2fc5fa9ab2b05e87a8f44e3b3f"
+checksum = "5eb4a7f0e4eb5aaa1032a396ef0b840f6b3cda399dfa74b9d5cfaf0c1b537260"
 dependencies = [
  "near-schema-checker-core",
  "near-schema-checker-macro",
@@ -2436,9 +2436,9 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e271c4d3f240580c96702ee0b40e9529174e651dcb8f1749a6ae7fe1c55751d"
+checksum = "24abafad706a94a56a687618ae7e13b296b0443f54c7b7d92477b3b3c82e336d"
 
 [[package]]
 name = "near-slip10"
@@ -2454,7 +2454,7 @@ dependencies = [
 [[package]]
 name = "near-socialdb-client"
 version = "0.15.1"
-source = "git+https://github.com/near/near-socialdb-client-rs?rev=c6c81d1a17bfd5275aa279b478b299721af108e8#c6c81d1a17bfd5275aa279b478b299721af108e8"
+source = "git+https://github.com/near/near-socialdb-client-rs?rev=66580af4ce6736056e3d6f15e6c93f0127b86aad#66580af4ce6736056e3d6f15e6c93f0127b86aad"
 dependencies = [
  "eyre",
  "near-crypto",
@@ -2469,15 +2469,15 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49f8c17fb0087367b6dbc6bb76b134329c0929e82f099e4baf65312d55f84d"
+checksum = "f1e1cf6e256646ef9cabf86759582b2e7b06edfde846edaa68fc7d3e69d833f8"
 
 [[package]]
 name = "near-time"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f410629742ba3e9103b274eb839bd89c7f6aaa3362b26495454d50efc917669"
+checksum = "3014c3edcc10d38313abd8401700b565ab555423eee090a1b1491c700ed711a2"
 dependencies = [
  "parking_lot",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "atomic-waker"
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.100"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "hex-conservative",
 ]
@@ -215,9 +215,9 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -302,12 +302,12 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -346,9 +346,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bytesize"
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a34f8b80c3b233269d3defad193678c74b4dcfd16aa0dab0e1b7b8d3e3c34eb"
+checksum = "5d7123d293f652da25899a771e48756075710465b2eedb0fc35aa3b368e9cf5c"
 dependencies = [
  "anyhow",
  "core-foundation 0.10.1",
@@ -373,6 +373,7 @@ dependencies = [
  "jobserver",
  "libc",
  "miow",
+ "portable-atomic",
  "same-file",
  "sha2 0.11.0",
  "shell-escape",
@@ -384,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -515,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1372,15 +1373,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1533,9 +1532,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -1725,12 +1724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1817,11 +1810,11 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
- "console 0.16.3",
+ "console 0.16.4",
  "portable-atomic",
  "unicode-width 0.2.2",
  "unit-prefix",
@@ -1935,9 +1928,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1982,12 +1975,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -2051,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -2179,8 +2166,9 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.27.0"
-source = "git+https://github.com/near/near-cli-rs?rev=e170e55345c05f57eab0f3527f4c6bcb73a492b9#e170e55345c05f57eab0f3527f4c6bcb73a492b9"
+version = "0.28.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063f4f39eafea13b6d447fa9d18ae108a9ce0d37061ded96434fdee57fc8434a"
 dependencies = [
  "bip39",
  "borsh",
@@ -2232,7 +2220,7 @@ dependencies = [
  "tracing-indicatif",
  "tracing-subscriber",
  "url",
- "wasmparser 0.243.0",
+ "wasmparser",
  "zstd",
 ]
 
@@ -2298,8 +2286,9 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "0.21.1"
-source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=4196c34db5c5e6acfc563d62ab16c68b7c666d7e#4196c34db5c5e6acfc563d62ab16c68b7c666d7e"
+version = "0.22.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249aacedbd175416a3635a83752581225b08a80e34bcba7ff65959c8954cf8e7"
 dependencies = [
  "borsh",
  "lazy_static",
@@ -2453,8 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "near-socialdb-client"
-version = "0.15.1"
-source = "git+https://github.com/near/near-socialdb-client-rs?rev=66580af4ce6736056e3d6f15e6c93f0127b86aad#66580af4ce6736056e3d6f15e6c93f0127b86aad"
+version = "0.16.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf155a85c6b9bd805beff5f7d0cfae6bcd113a952d13d21733d6bc3b9090a89"
 dependencies = [
  "eyre",
  "near-crypto",
@@ -2615,13 +2605,12 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
-version = "5.3.5"
+version = "5.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+checksum = "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a"
 dependencies = [
  "is-wsl",
  "libc",
- "pathdiff",
 ]
 
 [[package]]
@@ -2725,12 +2714,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,16 +2769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -2895,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2915,9 +2888,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -2950,9 +2923,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -3267,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "once_cell",
  "ring",
@@ -3281,9 +3254,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3932,7 +3905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4011,9 +3984,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4031,9 +4004,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4287,7 +4260,7 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1ef6990e0438749f0080573248e96631171a0b5ddfddde119aa5ba8c3a9c47e"
 dependencies = [
- "indicatif 0.18.4",
+ "indicatif 0.18.6",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -4448,9 +4421,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4526,23 +4499,14 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4554,9 +4518,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4564,9 +4528,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4574,9 +4538,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4587,33 +4551,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -4630,22 +4572,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4956,97 +4886,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.118",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser 0.244.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
-]
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,8 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dd54ba00e601c21619a33d6e127cf0d604ee6c3080d8989492a0faf88cbc5b4"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -2179,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "near-cli-rs"
 version = "0.27.0"
-source = "git+https://github.com/near/near-cli-rs?rev=178be1a97e19e354d5ca0e7b6a1531d9577f29fc#178be1a97e19e354d5ca0e7b6a1531d9577f29fc"
+source = "git+https://github.com/near/near-cli-rs?rev=f239a8fdc09d15c60c826f04c8544b1a8fba4418#f239a8fdc09d15c60c826f04c8544b1a8fba4418"
 dependencies = [
  "bip39",
  "borsh",
@@ -2237,8 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdc29612694210b340ff04d94c539e0d65007c97fc4763075a1d6038e58778a1"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -2248,8 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48363b16b2cfb9776c93c9ca9c470ed6437a2adb997afa0212372b3130cd944a"
 dependencies = [
  "aws-lc-rs",
  "blake2",
@@ -2275,8 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d603b7171fdb5f5200b4d805c9361d54bb2568e5b0636b4f2a3b37e5e3b7549b"
 dependencies = [
  "near-primitives-core",
 ]
@@ -2295,7 +2299,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.21.1"
-source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=5f5d150d47315745945fba7672bf8c90c5bf7f95#5f5d150d47315745945fba7672bf8c90c5bf7f95"
+source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=b1ea63913de39768f4c40affaaf958e79704710d#b1ea63913de39768f4c40affaaf958e79704710d"
 dependencies = [
  "borsh",
  "lazy_static",
@@ -2312,8 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2422d73d08d6e3add41e1237443699a27e6150962cbe91aeef14dc2e937a7d26"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -2329,8 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e376dc8810d6fa5bd295870c767a9418ef5f239e469ca0d7360bed3e89c703"
 dependencies = [
  "borsh",
  "enum-map",
@@ -2347,8 +2353,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ec7cdd531c3a0cd6c199f183ad6c74755d08344c13f4eab8edd1641fb74a18f"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -2389,8 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69db87d9459f45873002def58c11b0ff9c55454ca3793ac9cec396aaa0e27d"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -2412,13 +2420,15 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f9ab211568bffbc9b76fb87796a28fd4027cbaeccd4bd4743720d4de4fa48fd"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0170e3ee9be1a8f3d0fc5f3f21015fdc00aae2fc5fa9ab2b05e87a8f44e3b3f"
 dependencies = [
  "near-schema-checker-core",
  "near-schema-checker-macro",
@@ -2426,8 +2436,9 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e271c4d3f240580c96702ee0b40e9529174e651dcb8f1749a6ae7fe1c55751d"
 
 [[package]]
 name = "near-slip10"
@@ -2443,7 +2454,7 @@ dependencies = [
 [[package]]
 name = "near-socialdb-client"
 version = "0.15.1"
-source = "git+https://github.com/near/near-socialdb-client-rs?rev=2268c29c4e8ad095de2a511521f08411858a1811#2268c29c4e8ad095de2a511521f08411858a1811"
+source = "git+https://github.com/near/near-socialdb-client-rs?rev=c6c81d1a17bfd5275aa279b478b299721af108e8#c6c81d1a17bfd5275aa279b478b299721af108e8"
 dependencies = [
  "eyre",
  "near-crypto",
@@ -2458,13 +2469,15 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49f8c17fb0087367b6dbc6bb76b134329c0929e82f099e4baf65312d55f84d"
 
 [[package]]
 name = "near-time"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f410629742ba3e9103b274eb839bd89c7f6aaa3362b26495454d50efc917669"
 dependencies = [
  "parking_lot",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-validator"
-version = "0.1.13"
+version = "0.2.0"
 authors = [
     "FroVolod <frol_off@meta.ua>",
     "frol <frolvlad@gmail.com>",
@@ -49,17 +49,16 @@ self_update = { version = "0.42.0", features = [
     "compression-flate2",
 ], optional = true }
 
-# nearcore 2.13 (protocol v85): published 2.13 RC 0.37.0-rc.2; bump to 0.37.0
-# (drop pre-release) once 2.13 ships stable.
-near-crypto = "=0.37.0-rc.2"
-near-primitives = "=0.37.0-rc.2"
-near-jsonrpc-client = { version = "=0.22.0-rc.1", features = ["any"] }
-near-jsonrpc-primitives = "=0.37.0-rc.2"
+# nearcore 2.13 (protocol v85): pinned to 2.13.0 stable on crates.io.
+near-crypto = "0.37.0"
+near-primitives = "0.37.0"
+near-jsonrpc-client = { version = "0.22.0", features = ["any"] }
+near-jsonrpc-primitives = "0.37.0"
 
 interactive-clap = "0.3"
 interactive-clap-derive = "0.3"
 
-near-cli-rs = { version = "=0.28.0-rc.1", default-features = false }
+near-cli-rs = { version = "0.28.0", default-features = false }
 near-token = { version = "0.3", features = [
     "serde",
     "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,17 +50,16 @@ self_update = { version = "0.42.0", features = [
 ], optional = true }
 
 # nearcore 2.13 (protocol v85): published 2.13 RC 0.37.0-rc.2; bump to 0.37.0
-# (drop pre-release) once 2.13 ships stable. The jsonrpc client stays on its
-# matching 2.13 draft rev until it cuts a crates.io release.
-near-crypto = "0.37.0-rc.2"
-near-primitives = "0.37.0-rc.2"
-near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "4196c34db5c5e6acfc563d62ab16c68b7c666d7e", features = ["any"] }
-near-jsonrpc-primitives = "0.37.0-rc.2"
+# (drop pre-release) once 2.13 ships stable.
+near-crypto = "=0.37.0-rc.2"
+near-primitives = "=0.37.0-rc.2"
+near-jsonrpc-client = { version = "=0.22.0-rc.1", features = ["any"] }
+near-jsonrpc-primitives = "=0.37.0-rc.2"
 
 interactive-clap = "0.3"
 interactive-clap-derive = "0.3"
 
-near-cli-rs = { git = "https://github.com/near/near-cli-rs", rev = "e170e55345c05f57eab0f3527f4c6bcb73a492b9", default-features = false }
+near-cli-rs = { version = "=0.28.0-rc.1", default-features = false }
 near-token = { version = "0.3", features = [
     "serde",
     "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,18 +49,18 @@ self_update = { version = "0.42.0", features = [
     "compression-flate2",
 ], optional = true }
 
-# nearcore 2.13 (protocol v85) is not published to crates.io yet, so the
-# near-* crates are git-pinned to the 2.13-release rev (matching the rest of
-# the DevEx 2.13 stack). Swap back to crates.io versions once 2.13 ships.
-near-crypto = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
-near-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
-near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "5f5d150d47315745945fba7672bf8c90c5bf7f95", features = ["any"] }
-near-jsonrpc-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+# nearcore 2.13 (protocol v85): published 2.13 RC 0.37.0-rc.1; bump to 0.37.0
+# (drop pre-release) once 2.13 ships stable. The jsonrpc client stays on its
+# matching 2.13 draft rev until it cuts a crates.io release.
+near-crypto = "0.37.0-rc.1"
+near-primitives = "0.37.0-rc.1"
+near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "b1ea63913de39768f4c40affaaf958e79704710d", features = ["any"] }
+near-jsonrpc-primitives = "0.37.0-rc.1"
 
 interactive-clap = "0.3"
 interactive-clap-derive = "0.3"
 
-near-cli-rs = { git = "https://github.com/near/near-cli-rs", rev = "178be1a97e19e354d5ca0e7b6a1531d9577f29fc", default-features = false }
+near-cli-rs = { git = "https://github.com/near/near-cli-rs", rev = "f239a8fdc09d15c60c826f04c8544b1a8fba4418", default-features = false }
 near-token = { version = "0.3", features = [
     "serde",
     "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,18 @@ self_update = { version = "0.42.0", features = [
     "compression-flate2",
 ], optional = true }
 
-near-crypto = "0.36"
-near-primitives = "0.36"
-near-jsonrpc-client = { version = "0.21.1", features = ["any"] }
-near-jsonrpc-primitives = "0.36"
+# nearcore 2.13 (protocol v85) is not published to crates.io yet, so the
+# near-* crates are git-pinned to the 2.13-release rev (matching the rest of
+# the DevEx 2.13 stack). Swap back to crates.io versions once 2.13 ships.
+near-crypto = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "5f5d150d47315745945fba7672bf8c90c5bf7f95", features = ["any"] }
+near-jsonrpc-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
 
 interactive-clap = "0.3"
 interactive-clap-derive = "0.3"
 
-near-cli-rs = { version = "0.27", default-features = false }
+near-cli-rs = { git = "https://github.com/near/near-cli-rs", rev = "178be1a97e19e354d5ca0e7b6a1531d9577f29fc", default-features = false }
 near-token = { version = "0.3", features = [
     "serde",
     "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,18 +49,18 @@ self_update = { version = "0.42.0", features = [
     "compression-flate2",
 ], optional = true }
 
-# nearcore 2.13 (protocol v85): published 2.13 RC 0.37.0-rc.1; bump to 0.37.0
+# nearcore 2.13 (protocol v85): published 2.13 RC 0.37.0-rc.2; bump to 0.37.0
 # (drop pre-release) once 2.13 ships stable. The jsonrpc client stays on its
 # matching 2.13 draft rev until it cuts a crates.io release.
-near-crypto = "0.37.0-rc.1"
-near-primitives = "0.37.0-rc.1"
-near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "b1ea63913de39768f4c40affaaf958e79704710d", features = ["any"] }
-near-jsonrpc-primitives = "0.37.0-rc.1"
+near-crypto = "0.37.0-rc.2"
+near-primitives = "0.37.0-rc.2"
+near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "4196c34db5c5e6acfc563d62ab16c68b7c666d7e", features = ["any"] }
+near-jsonrpc-primitives = "0.37.0-rc.2"
 
 interactive-clap = "0.3"
 interactive-clap-derive = "0.3"
 
-near-cli-rs = { git = "https://github.com/near/near-cli-rs", rev = "f239a8fdc09d15c60c826f04c8544b1a8fba4418", default-features = false }
+near-cli-rs = { git = "https://github.com/near/near-cli-rs", rev = "e170e55345c05f57eab0f3527f4c6bcb73a492b9", default-features = false }
 near-token = { version = "0.3", features = [
     "serde",
     "borsh",

--- a/src/staking/mod.rs
+++ b/src/staking/mod.rs
@@ -30,3 +30,46 @@ pub enum StakingCommand {
     /// To unstake NEAR directly without a staking pool
     UnstakeProposal(self::unstake_proposal::UnstakeProposal),
 }
+
+/// Validator stake keys must be ed25519. nearcore only accepts a
+/// ristretto-convertible ed25519 key in a `StakeAction`, and the 2.13
+/// `near-crypto` bump makes `PublicKey` also parse `ml-dsa-65:` / `secp256k1:`
+/// keys (those are transaction/access keys, not validator keys). Reject
+/// anything but ed25519 up front so the user gets a clear input error instead
+/// of a deterministic on-chain rejection.
+fn ensure_ed25519_validator_key(
+    public_key: &near_crypto::PublicKey,
+) -> color_eyre::eyre::Result<()> {
+    if !matches!(public_key.key_type(), near_crypto::KeyType::ED25519) {
+        color_eyre::eyre::bail!(
+            "Validator stake keys must be ed25519, but a `{}` key was provided.\n\
+             Staking requires a ristretto-convertible ed25519 validator key; \
+             ml-dsa-65 and secp256k1 keys are only valid as access/transaction keys.",
+            public_key.key_type()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_ed25519_validator_key;
+    use near_crypto::{KeyType, SecretKey};
+
+    #[test]
+    fn accepts_ed25519_validator_key() {
+        let public_key = SecretKey::from_random(KeyType::ED25519).public_key();
+        assert!(ensure_ed25519_validator_key(&public_key).is_ok());
+    }
+
+    #[test]
+    fn rejects_non_ed25519_validator_keys() {
+        for key_type in [KeyType::MLDSA65, KeyType::SECP256K1] {
+            let public_key = SecretKey::from_random(key_type).public_key();
+            assert!(
+                ensure_ed25519_validator_key(&public_key).is_err(),
+                "{key_type} key must be rejected as a validator stake key"
+            );
+        }
+    }
+}

--- a/src/staking/stake_proposal.rs
+++ b/src/staking/stake_proposal.rs
@@ -30,10 +30,12 @@ impl StakeProposalContext {
         previous_context: near_cli_rs::GlobalContext,
         scope: &<StakeProposal as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
+        let public_key: near_crypto::PublicKey = scope.public_key.clone().into();
+        super::ensure_ed25519_validator_key(&public_key)?;
         Ok(Self {
             global_context: previous_context,
             validator: scope.validator.clone().into(),
-            public_key: scope.public_key.clone().into(),
+            public_key,
             stake: scope.stake,
         })
     }

--- a/src/staking/unstake_proposal.rs
+++ b/src/staking/unstake_proposal.rs
@@ -24,10 +24,12 @@ impl UnstakeProposalContext {
         previous_context: near_cli_rs::GlobalContext,
         scope: &<UnstakeProposal as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
+        let public_key: near_crypto::PublicKey = scope.public_key.clone().into();
+        super::ensure_ed25519_validator_key(&public_key)?;
         Ok(Self {
             global_context: previous_context,
             validator: scope.validator.clone().into(),
-            public_key: scope.public_key.clone().into(),
+            public_key,
         })
     }
 }


### PR DESCRIPTION
## Summary

Pins near-validator to the published nearcore **2.13.0** stable stack (protocol v85) now on crates.io. For near-validator this is purely a dependency bump — the CLI-side ML-DSA-65 keygen lives in near-cli-rs. Releases near-validator **0.2.0** (nearcore major-dep bump is breaking for a 0.x crate).

## Dependencies (`Cargo.toml`)

- `near-crypto` / `near-primitives` / `near-jsonrpc-primitives`: `0.37.0-rc.2` → `0.37.0`
- `near-jsonrpc-client`: `0.22.0-rc.1` → `0.22.0`
- `near-cli-rs`: `0.28.0-rc.1` → `0.28.0` (`default-features = false`)

## Windows / CI

Keeps `AWS_LC_SYS_PREBUILT_NASM: "1"` in the release workflow: 2.13's post-quantum `near-crypto` pulls `aws-lc-sys`, which needs NASM on x86_64 Windows.

## Gate

Blocked on `near-cli-rs 0.28.0` (and `near-jsonrpc-client 0.22.0`) publishing to crates.io as part of the 2.13.0 stable cascade; until then a full build cannot resolve. `cargo fmt --check` passes.